### PR TITLE
AncientSettings: Add visualizer feature [2/2]

### DIFF
--- a/res/values/ancient_strings.xml
+++ b/res/values/ancient_strings.xml
@@ -701,4 +701,20 @@
     <string name="lockscreen_status_bar_title">Status bar</string>
     <string name="lockscreen_status_bar_summary">Display status bar on the lockscreen</string>
 
+    <!-- Lock screen visualizer -->
+    <string name="lockscreenholder_title">LockScreen Holder</string>
+    <string name="lockscreen_visualizer_title">LockScreen Visualizer</string>
+    <string name="lockscreen_visualizer_enable">Music Visualizer</string>
+    <string name="lockscreen_visualizer_enable_summary">Show visualizer bars while playing music</string>
+    <string name="lockscreen_visualizer_summary">Display music visualizer when available</string>
+    <string name="lockscreen_autocolor_title">Automatic color</string>
+    <string name="lockscreen_autocolor_summary">Sync color with background</string>
+    <string name="lockscreen_autocolor_lavalamp">Requires lava lamp disabled</string>
+    <string name="lockscreen_lavalamp_title">Lava lamp</string>
+    <string name="lockscreen_lavalamp_summary">Animate smooth lava lamp style color blend</string>
+    <string name="lockscreen_lavalamp_speed_title">Lava lamp color blend interval</string>
+    <string name="lockscreen_solid_units_count_title">Solid lines count</string>
+    <string name="lockscreen_solid_fudge_factor_title">Sanity level</string>
+    <string name="lockscreen_solid_units_opacity_title">Solid lines opacity</string>
+    <string name="unit_milliseconds">ms</string>
 </resources>

--- a/res/xml/ancient_settings_lockscreen.xml
+++ b/res/xml/ancient_settings_lockscreen.xml
@@ -89,6 +89,12 @@
             android:summary="@string/lockscreen_status_bar_summary"
             android:defaultValue="true" />
 
+        <Preference
+            android:key="lockscreen_visualizer_enabled"
+            android:title="@string/lockscreen_visualizer_enable"
+            android:summary="@string/lockscreen_visualizer_enable_summary"
+            android:fragment="com.ancient.settings.fragments.lockscreen.LockScreenVisualizer" />
+
         <com.ancient.settings.preferences.SystemSettingSwitchPreference
             android:key="lockscreen_media_metadata"
             android:title="@string/media_art_title"

--- a/res/xml/lockscreen_visualizer.xml
+++ b/res/xml/lockscreen_visualizer.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2019 crDroid Android Project
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+          http://www.apache.org/licenses/LICENSE-2.0
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:settings="http://schemas.android.com/apk/res/com.android.settings"
+    android:title="@string/lockscreen_visualizer_title" >
+
+    <com.ancient.settings.preferences.SecureSettingSwitchPreference
+        android:key="lockscreen_visualizer"
+        android:title="@string/lockscreen_visualizer_title"
+        android:summary="@string/lockscreen_visualizer_summary"
+        android:defaultValue="true" />
+
+    <com.ancient.settings.preferences.SecureSettingSwitchPreference
+       android:key="lockscreen_visualizer_autocolor"
+        android:title="@string/lockscreen_autocolor_title"
+        android:summary="@string/lockscreen_autocolor_summary"
+        android:defaultValue="false"
+        android:dependency="lockscreen_visualizer"/>
+
+    <com.ancient.settings.preferences.SecureSettingSwitchPreference
+        android:key="lockscreen_lavalamp_enabled"
+        android:title="@string/lockscreen_lavalamp_title"
+        android:summary="@string/lockscreen_lavalamp_summary"
+        android:defaultValue="true"
+        android:dependency="lockscreen_visualizer"/>
+
+    <com.ancient.settings.preferences.CustomSecureSeekBarPreference
+        android:key="lockscreen_lavalamp_speed"
+        android:title="@string/lockscreen_lavalamp_speed_title"
+        android:defaultValue="10000"
+        android:max="30000"
+        settings:min="200"
+        settings:interval="200"
+        settings:units="@string/unit_milliseconds"
+        android:dependency="lockscreen_lavalamp_enabled"/>
+
+    <com.ancient.settings.preferences.CustomSecureSeekBarPreference
+        android:key="lockscreen_solid_units_count"
+        android:title="@string/lockscreen_solid_units_count_title"
+        android:defaultValue="32"
+        android:max="128"
+        settings:min="16"
+        settings:interval="16"
+        android:dependency="lockscreen_visualizer"/>
+
+    <com.ancient.settings.preferences.CustomSecureSeekBarPreference
+        android:key="lockscreen_solid_fudge_factor"
+        android:title="@string/lockscreen_solid_fudge_factor_title"
+        android:defaultValue="16"
+        android:max="32"
+        settings:min="2"
+        android:dependency="lockscreen_visualizer"/>
+
+    <com.ancient.settings.preferences.CustomSecureSeekBarPreference
+        android:key="lockscreen_solid_units_opacity"
+        android:title="@string/lockscreen_solid_units_opacity_title"
+        android:defaultValue="140"
+        android:max="255"
+        settings:min="0"
+        android:dependency="lockscreen_visualizer"/>
+</PreferenceScreen> 

--- a/src/com/ancient/settings/fragments/lockscreen/LockScreenVisualizer.java
+++ b/src/com/ancient/settings/fragments/lockscreen/LockScreenVisualizer.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2019 crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ancient.settings.fragments.lockscreen;
+
+import android.app.Activity;
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.UserHandle;
+import android.provider.Settings;
+
+import androidx.preference.ListPreference;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceScreen;
+import androidx.preference.Preference.OnPreferenceChangeListener;
+import androidx.preference.SwitchPreference;
+
+import com.android.internal.logging.nano.MetricsProto;
+import com.android.settings.SettingsPreferenceFragment;
+
+import com.android.settings.R;
+import com.ancient.settings.preferences.CustomSeekBarPreference;
+
+public class LockScreenVisualizer extends SettingsPreferenceFragment
+            implements Preference.OnPreferenceChangeListener  {
+
+    public static final String TAG = "LockScreenVisualizer";
+
+    private static final String KEY_AUTOCOLOR = "lockscreen_visualizer_autocolor";
+    private static final String KEY_LAVALAMP = "lockscreen_lavalamp_enabled";
+
+    private SwitchPreference mAutoColor;
+    private SwitchPreference mLavaLamp;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        addPreferencesFromResource(R.xml.lockscreen_visualizer);
+
+        ContentResolver resolver = getActivity().getContentResolver();
+
+        boolean mLavaLampEnabled = Settings.Secure.getIntForUser(resolver,
+                Settings.Secure.LOCKSCREEN_LAVALAMP_ENABLED, 1,
+                UserHandle.USER_CURRENT) != 0;
+
+        mAutoColor = (SwitchPreference) findPreference(KEY_AUTOCOLOR);
+        mAutoColor.setEnabled(!mLavaLampEnabled);
+
+        if (mLavaLampEnabled) {
+            mAutoColor.setSummary(getActivity().getString(
+                    R.string.lockscreen_autocolor_lavalamp));
+        } else {
+            mAutoColor.setSummary(getActivity().getString(
+                    R.string.lockscreen_autocolor_summary));
+        }
+
+        mLavaLamp = (SwitchPreference) findPreference(KEY_LAVALAMP);
+        mLavaLamp.setOnPreferenceChangeListener(this);
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object newValue) {
+        ContentResolver resolver = getActivity().getContentResolver();
+
+        if (preference == mLavaLamp) {
+            boolean mLavaLampEnabled = (Boolean) newValue;
+            mAutoColor.setEnabled(!mLavaLampEnabled);
+
+            if (mLavaLampEnabled) {
+                mAutoColor.setSummary(getActivity().getString(
+                        R.string.lockscreen_autocolor_lavalamp));
+            } else {
+                mAutoColor.setSummary(getActivity().getString(
+                        R.string.lockscreen_autocolor_summary));
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public static void reset(Context mContext) {
+        ContentResolver resolver = mContext.getContentResolver();
+        Settings.Secure.putIntForUser(resolver,
+                Settings.Secure.LOCKSCREEN_VISUALIZER_ENABLED, 1, UserHandle.USER_CURRENT);
+        Settings.Secure.putIntForUser(resolver,
+                Settings.Secure.LOCKSCREEN_LAVALAMP_ENABLED, 1, UserHandle.USER_CURRENT);
+        Settings.Secure.putIntForUser(resolver,
+                Settings.Secure.LOCKSCREEN_LAVALAMP_SPEED, 10000, UserHandle.USER_CURRENT);
+        Settings.Secure.putIntForUser(resolver,
+                Settings.Secure.LOCKSCREEN_VISUALIZER_AUTOCOLOR, 0, UserHandle.USER_CURRENT);
+        Settings.Secure.putIntForUser(resolver,
+                Settings.Secure.LOCKSCREEN_SOLID_UNITS_COUNT, 32, UserHandle.USER_CURRENT);
+        Settings.Secure.putIntForUser(resolver,
+                Settings.Secure.LOCKSCREEN_SOLID_FUDGE_FACTOR, 16, UserHandle.USER_CURRENT);
+        Settings.Secure.putIntForUser(resolver,
+                Settings.Secure.LOCKSCREEN_SOLID_UNITS_OPACITY, 140, UserHandle.USER_CURRENT);
+    }
+
+    @Override
+    public int getMetricsCategory() {
+        return MetricsProto.MetricsEvent.ANCIENT_SETTINGS;
+    }
+}

--- a/src/com/ancient/settings/fragments/lockscreen/LockscreenHolder.java
+++ b/src/com/ancient/settings/fragments/lockscreen/LockscreenHolder.java
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2015-2019 Android Open Source Illusion Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ancient.settings.fragments.lockscreen;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.os.Bundle;
+import android.os.ServiceManager;
+import android.provider.SearchIndexableResource;
+import androidx.preference.Preference;
+
+import com.android.internal.logging.nano.MetricsProto.MetricsEvent;
+import com.android.settings.R;
+import com.android.settings.search.BaseSearchIndexProvider;
+import com.android.settings.search.Indexable;
+import com.android.settings.SettingsPreferenceFragment;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class LockscreenHolder extends SettingsPreferenceFragment implements
+        Preference.OnPreferenceChangeListener, Indexable {
+
+    @Override
+    public int getMetricsCategory() {
+        return MetricsEvent.ANCIENT_SETTINGS;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        addPreferencesFromResource(R.xml.ancient_settings_lockscreen);
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+    }
+
+    public boolean onPreferenceChange(Preference preference, Object newValue) {
+        return false;
+    }
+
+    public static void reset(Context mContext) {
+        ContentResolver resolver = mContext.getContentResolver();
+        LockScreenVisualizer.reset(mContext);
+    }
+
+    /**
+     * For Search.
+     */
+    public static final SearchIndexProvider SEARCH_INDEX_DATA_PROVIDER =
+            new BaseSearchIndexProvider() {
+                 @Override
+                public List<SearchIndexableResource> getXmlResourcesToIndex(Context context,
+                        boolean enabled) {
+                    final ArrayList<SearchIndexableResource> result = new ArrayList<>();
+                     final SearchIndexableResource sir = new SearchIndexableResource(context);
+                    sir.xmlResId = R.xml.ancient_settings_lockscreen;
+                    result.add(sir);
+                    return result;
+                }
+                 @Override
+                public List<String> getNonIndexableKeys(Context context) {
+                    final List<String> keys = super.getNonIndexableKeys(context);
+                    return keys;
+                }
+    };
+}
+

--- a/src/com/ancient/settings/preferences/CustomSecureSeekBarPreference.java
+++ b/src/com/ancient/settings/preferences/CustomSecureSeekBarPreference.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2017 AICP
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ancient.settings.preferences;
+
+import android.content.Context;
+import android.util.AttributeSet;
+
+public class CustomSecureSeekBarPreference extends CustomSeekBarPreference {
+
+    public CustomSecureSeekBarPreference(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+        setPreferenceDataStore(new SecureSettingsStore(context.getContentResolver()));
+    }
+
+    public CustomSecureSeekBarPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        setPreferenceDataStore(new SecureSettingsStore(context.getContentResolver()));
+    }
+
+    public CustomSecureSeekBarPreference(Context context) {
+        super(context, null);
+        setPreferenceDataStore(new SecureSettingsStore(context.getContentResolver()));
+    }
+}
+


### PR DESCRIPTION
Change-Id: Id0e354d15b90fc1e6e5b8b42e5e448185d730078

Lockscreen Visualizer: Add pulse magic

Change-Id: I6bf913ce3d4b0c23f5b8aaa6c310222c53409a60

lockscreen: Change visualizer switch to a fragment preference

Visualizer: Fix repeated definitions

Visualizer: Add missing definitions

Message:
packages/apps/AncientSettings/res/xml/lockscreen_visualizer.xml:19: error: resource string/lockscreen_visualizer_title (aka com.android.settings:string/lockscreen_visualizer_title) not found.

Update LockscreenHolder.java

Update LockScreenVisualizer.java

Update CustomSecureSeekBarPreference.java

Update LockScreenVisualizer.java

Update lockscreen_visualizer.xml

Update LockscreenHolder.java